### PR TITLE
Robustify outdated-version translation

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -201,8 +201,8 @@ var i18n = {
     'Work phone': 'Τηλέφωνο εργασίας',
     'Home phone': 'Τηλέφωνο οικίας',
     'Main phone': 'Κύριο τηλέφωνο',
-    // TODO: 'It looks like you are using an outdated version of this script. You can find the latest one': '',
-    // TODO: 'here': '',
+    // TODO: 'It looks like you are using an outdated version of this script': '',
+    // TODO: 'You can find the latest one here': '',
   },
   'es': {
     'Age': 'Edad',
@@ -225,8 +225,8 @@ var i18n = {
     'Work phone': 'Teléfono del trabajo',
     'Home phone': 'Teléfono del hogar',
     'Main phone': 'Teléfono principal',
-    // TODO: 'It looks like you are using an outdated version of this script. You can find the latest one': '',
-    // TODO: 'here': '',
+    // TODO: 'It looks like you are using an outdated version of this script': '',
+    // TODO: 'You can find the latest one here': '',
   },
   'it': {
     'Age': 'Età',
@@ -249,8 +249,8 @@ var i18n = {
     'Work phone': 'Telefono di lavoro',
     'Home phone': 'Telefono di casa',
     'Main phone': 'Telefono principale',
-    'It looks like you are using an outdated version of this script. You can find the latest one': 'Sembra che tu stia usando una vecchia versione di questo script. Puoi trovare l\'ultima',
-    'here': 'qui',
+    'It looks like you are using an outdated version of this script': 'Sembra che tu stia usando una vecchia versione di questo script',
+    'You can find the latest one here': 'Puoi trovare l\'ultima qui',
   },
   'id': {
     'Age': 'Usia',
@@ -273,8 +273,8 @@ var i18n = {
     'Work phone': 'Telp. Kantor',
     'Home phone': 'Telp. Rumah',
     'Main phone': 'Telp. Utama',
-    // TODO: 'It looks like you are using an outdated version of this script. You can find the latest one': '',
-    // TODO: 'here': '',
+    // TODO: 'It looks like you are using an outdated version of this script': '',
+    // TODO: 'You can find the latest one here': '',
   },
   'de': {
     'Age': 'Alter',
@@ -297,8 +297,8 @@ var i18n = {
     'Work phone': 'Geschäftlich',
     'Home phone': 'Privat',
     'Main phone': 'Hauptnummer',
-    // TODO: 'It looks like you are using an outdated version of this script. You can find the latest one': '',
-    // TODO: 'here': '',
+    // TODO: 'It looks like you are using an outdated version of this script': '',
+    // TODO: 'You can find the latest one here': '',
   },
   'pl': {
     'Age': 'Wiek',
@@ -321,8 +321,8 @@ var i18n = {
     'Work phone': 'Telefon (praca)',
     'Home phone': 'Telefon (domowy)',
     'Main phone': 'Telefon (główny)',
-    // TODO: 'It looks like you are using an outdated version of this script. You can find the latest one': '',
-    // TODO: 'here': '',
+    // TODO: 'It looks like you are using an outdated version of this script': '',
+    // TODO: 'You can find the latest one here': '',
   },
   /* To add a language:
   '[lang-code]': {
@@ -436,7 +436,7 @@ function doLog (arg) {
  */
 function checkEvents (testDate) {
   var anticipate, subjectPrefix, subjectBuilder,
-    bodyPrefix, bodySuffix1, bodySuffix2, bodySuffix3, bodyBuilder, htmlBodyBuilder, now, subject, body, htmlBody;
+    bodyPrefix, bodySuffix1, bodySuffix2, bodySuffix3, bodySuffix4, bodyBuilder, htmlBodyBuilder, now, subject, body, htmlBody;
 
   doLog('Starting run of Google Contacts Events Notifier version ' + version + '.');
   // The script needs this value in milliseconds, but the user entered it in days.
@@ -452,7 +452,9 @@ function checkEvents (testDate) {
   bodyPrefix = _('Hey! Don\'t forget these events') + ':';
   bodySuffix1 = _('Google Contacts Events Notifier') + ' (' + _('version') + ' ' + version + ')';
   bodySuffix2 = _('by') + ' Giorgio Bonvicini';
-  bodySuffix3 = _('It looks like you are using an outdated version of this script. You can find the latest one');
+  bodySuffix3 = _('It looks like you are using an outdated version of this script') + '.';
+  bodySuffix4 = _('You can find the latest one here');
+
   // The email is built both with plain text and HTML text.
   bodyBuilder = [];
   htmlBodyBuilder = [];
@@ -550,12 +552,12 @@ function checkEvents (testDate) {
     body = [bodyPrefix, '\n']
         .concat(bodyBuilder)
         .concat(['\n\n ', bodySuffix1, '\n ', bodySuffix2, '\n'])
-        .concat('\n', isRunningOutdatedVersion() ? [bodySuffix3, ' ', _('here'), ':\n', baseGitHubProjectURL + 'releases/latest', '\n '] : [])
+        .concat('\n', isRunningOutdatedVersion() ? [bodySuffix3, ' ', bodySuffix4, ':\n', baseGitHubProjectURL + 'releases/latest', '\n '] : [])
         .join('');
     htmlBody = ['<h3>', htmlEscape(bodyPrefix), '</h3><dl>']
         .concat(htmlBodyBuilder)
         .concat(['</dl><hr/><p style="text-align:center;font-size:smaller"><a href="' + baseGitHubProjectURL + '">', htmlEscape(bodySuffix1), '</a><br/>', htmlEscape(bodySuffix2)])
-        .concat(isRunningOutdatedVersion() ? ['<br/><br/><b>', htmlEscape(bodySuffix3), ' ', '<a href="', baseGitHubProjectURL + 'releases/latest', '">', _('here'), '</a>.</b></p>'] : ['</p>'])
+        .concat(isRunningOutdatedVersion() ? ['<br/><br/><b>', htmlEscape(bodySuffix3), ' <a href="', baseGitHubProjectURL, 'releases/latest', '">', htmlEscape(bodySuffix4), '</a>.</b></p>'] : ['</p>'])
         .join('');
 
     // ...send the email notification.


### PR DESCRIPTION
This is the translation fixup as discussed in #34 (I thought it wiser to PR instead of straight push, just so another pair of eyes sees it first before translators see it and wonder if they should proceed - it should only take a minute to visually scan it). Then the issue can be un-suspended for people to do translations.