### PR TITLE
Workaround to mail not being sent if a contact has birthday only in G+

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ __verify that you followed [the instructions][Project documentation] to the
 letter.__
 
 To report a bug or an error or to request help with this script please use [this
-project GitHub issue page](Project issue page): I will be notified immediately
+project GitHub issue page][Project issue page]: I will be notified immediately
 and will provide help as soon as possible.
 
 In the text of the message please follow the [template provided][Issue template

--- a/code.gs
+++ b/code.gs
@@ -743,15 +743,19 @@ var Contact = function (event, eventType) {
     }
 
     // Store information for each event (name and years passed).
-    dates.forEach(function (eachDate) {
-      var dateLabel = eachDate.getLabel();
-      doLog('Has ' + dateLabel + ' year.');
-      self.dateLabels.push(dateLabel);
-      startYear = eachDate.getYear();
-      if (startYear) {
-        self.age[dateLabel] = (currentYear - startYear).toFixed(0);
-      }
-    });
+    if(dates[0] !== undefined) { // When contact has birtday field only in G+ part dates variable is empty 
+      dates.forEach(function (eachDate) {  
+        var dateLabel = eachDate.getLabel();  
+        doLog('Has ' + dateLabel + ' year.');  
+        self.dateLabels.push(dateLabel);  
+        startYear = eachDate.getYear();  
+        if (startYear) {  
+          self.age[dateLabel] = (currentYear - startYear).toFixed(0);  
+        }  
+      });
+    } else {
+      self.dateLabels.push(self.eventType);
+    }
 
     // Extract contact's phone numbers.
     phoneFields = googleContact.getPhones();


### PR DESCRIPTION
Workaround for issue #48 

What I discovered during creating that 'workaround' is that the line `dates = [googleContact.getDates(ContactsApp.Field[self.eventType])[0]];` returns empty (null?) dates variable if the birthday field in Contact part is empty, but in G+ is not.

Doing only the if part (without else) made the mail sent, but with almost empty content
![image](https://user-images.githubusercontent.com/6292364/29916940-98cb4648-8e40-11e7-8240-cc2964a76363.png)
However, the title of the email was written OK (there was the name of correct contact).

When I did the else case (which is very bad, but works) the mail was sent correctly with all the details, but without the age (`self.age['workaround'] = 'can\'t calculate';`).

I tried to just skip printing age in the mail, but couldn't find how to do it...
