### PR TITLE
Make contributing more translator friendly

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -74,6 +74,9 @@ Code consistency is what makes a project maintainable and accessible to
 everyone. To maintain consistency please make sure that your code submitted via
 Pull Requests complies with these rules:
 
+- If contributing translation strings you just need to ensure they are correctly
+  formatted (see the first point below under [Testing](#Testing)), and you can
+  ignore all the other guidelines/testing instructions;
 - The code must be in English (variable names, comments, documentation...);
 - The code in `.gs` files must be formatted following the [Javascript
   Semistandard Style][Javascript semistandard];

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -228,8 +228,8 @@ This is the optimal workflow that should be followed when managing a new PR:
 11. If any issues remain open which would be auto-closed by the PR when its
     target-branch finally gets merged to the default-branch (`master`), and it
     will be a noticeable length of time before that will happen, then either the
-    `solved` or `wontfix` tag should be added to those issues to make it clear at
-    a glance that nothing else needs doing for them in order for them to
+    `solved` or `wontfix` label should be added to those issues to make it clear
+    at a glance that nothing else needs doing for them in order for them to
     auto-close.
 
 ## Git mini-tutorial

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Code consistency is what makes a project maintainable and accessible to
 everyone. To maintain consistency please make sure that your code submitted via
 Pull Requests complies with these rules:
 
-- The code must be in english (variable names, comments, documentation...);
+- The code must be in English (variable names, comments, documentation...);
 - The code in `.gs` files must be formatted following the [Javascript
   Semistandard Style][Javascript semistandard];
 - The text in `.md` files must be formatted following the [Markdown CommonMark


### PR DESCRIPTION
Add a simple guideline for translators (who are only adding translation-strings) at the top of the list, explaining to ignore all the other instructions (so they don't get scared off) ...and a couple of nitpick-commits for words in CONTRIBUTING.