### PR TITLE
Clarified instructions (Copy of #80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ use you should never need or want to edit these.
 
 Now that the script is saved in your Google Drive folder we need to activate it.
 To do so click the menu `Resources->Advanced Google services`.  
-In the popup which will open set "Google Calendar API" to `enabled` (click the
-switch on its row on the right).  
-Once you have done this click on the link which says "Google API Console": you
+In the popup which will open set "Calendar API" to `enabled` (click the
+switch on its row on the right) and press "Okay".  
+Once you have done this open `Resources->Advanced Google services` again and click on the link which says "Google API Console": you
 will be taken to another page. In this page search for "Google Calendar API" and
 open it. Now click `Enable` at the top of the window and close this page.  
 Unless you have set the `accessGooglePlus` setting to `false`, then repeat these

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Now that the script is saved in your Google Drive folder we need to activate it.
 To do so click the menu `Resources->Advanced Google services`.  
 In the popup which will open set "Calendar API" to `enabled` (click the
 switch on its row on the right) and press "Okay".  
-Once you have done this open `Resources->Advanced Google services` again and click on the link which says "Google API Console": you
+Once you have done this open `Resources->Advanced Google services` again and 
+click on the link which says "Google API Console": you
 will be taken to another page. In this page search for "Google Calendar API" and
 open it. Now click `Enable` at the top of the window and close this page.  
 Unless you have set the `accessGooglePlus` setting to `false`, then repeat these


### PR DESCRIPTION
Instructions weren't inherently wrong, but if you close the Advanced Google services tab before clicking 'Okay' (i.e. when you open Google API) it doesn't save.

Copy of #80 https://github.com/GioBonvi/GoogleContactsEventsNotifier/pull/80#issuecomment-334549457 but for the development branch.