### PR TITLE
Few bug fixes

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -536,7 +536,7 @@ Contact.prototype.getLines = function (type, date, format) {
     }
     return typeMatch && event.getProp('day') === date.getDate() && event.getProp('month') === (date.getMonth() + 1);
   }).map(function (event) {
-    var line, imgCount;
+    var line, eventLabel, imgCount;
 
     line = [];
     // Start line.
@@ -561,12 +561,13 @@ Contact.prototype.getLines = function (type, date, format) {
     }
     // Custom label
     if (type === 'CUSTOM') {
+      eventLabel = event.getProp('label') || 'OTHER';
       switch (format) {
         case NotificationType.PLAIN_TEXT:
-          line.push('<', beautifyLabel(event.getProp('label')), '> ');
+          line.push('<', beautifyLabel(eventLabel), '> ');
           break;
         case NotificationType.HTML:
-          line.push(htmlEscape('<' + beautifyLabel(event.getProp('label')) + '> '));
+          line.push(htmlEscape('<' + beautifyLabel(eventLabel) + '> '));
       }
     }
     // Full name.

--- a/code.gs
+++ b/code.gs
@@ -1505,6 +1505,9 @@ function _ (str) {
  */
 function beautifyLabel (label) {
   switch (String(label)) {
+    /*
+     * Phone labels:
+     */
     case 'MOBILE_PHONE':
     case 'WORK_PHONE':
     case 'HOME_PHONE':
@@ -1513,10 +1516,19 @@ function beautifyLabel (label) {
     case 'WORK_FAX':
     case 'GOOGLE_VOICE':
     case 'PAGER':
+    case 'OTHER_PHONE': // Fake label for output.
+    /*
+     * (falls through)
+     * Email labels:
+     */
     case 'HOME_EMAIL':
     case 'WORK_EMAIL':
     case 'OTHER_EMAIL': // Fake label for output.
-    case 'OTHER_PHONE': // Fake label for output,
+    /*
+     * (falls through)
+     * Event labels:
+     */
+    case 'OTHER':
       return _(label[0] + label.slice(1).replaceAll('_', ' ').toLowerCase());
     default:
       return String(label);

--- a/tests.gs
+++ b/tests.gs
@@ -103,7 +103,7 @@ function testSemVer () {
 /**
  * Test all events from the selected period. It won't send actual e-mails to you, but put content of them into the log.
  *
- * **NB:** Execution of this function very often exceeds maximum time (30s).
+ * **NB:** Execution of this function very often exceeds maximum time (5min - 300s).
  *
  * @param {Date} [testDate=01/01/CURRENT_YEAR] - First date to test.
  * @param {number} [numberOfDaysToTest=365] - Number of days to test.


### PR DESCRIPTION
When testing v4.0.0 I found few small bugs that I patched.

1. When an event has 'Other' label (which you can select in Google Contacts - Birthday/Anniversary/Other) 'OTHER' is printed. I know this commit creates some problems with js-semistandard, but IMO it looks more organized that way. We can silence those warnings with comments, but I don't know how to write them.

2. When an event has a blank label (nothing selected, no custom text entered) 'null' is printed. I decided to put there 'Other' label, but I can change it to not print anything at all if that is a better solution.

3. Updated info about the maximum execution time of a single function. At the beginning I just put the info that @GioBonvi said in some comment, now I checked that in Google Script docs.