### PR TITLE
Improve version check

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1773,16 +1773,17 @@ function htmlEscape (str) {
  * @returns {boolean} - True if the script version is lower than the latest released one, false otherwise.
  */
 function isRunningOutdatedVersion () {
-  var response, latestVersion;
+  var response, latestVersion, fetchTries;
 
   // Retrieve the last version info.
+  fetchTries = 2;
   try {
-    response = cache.retrieve(baseGitHubApiURL + 'releases/latest');
+    response = cache.retrieve(baseGitHubApiURL + 'releases/latest', fetchTries);
     if (response === null) {
       throw new Error('');
     }
   } catch (err) {
-    log.add('Unable to get the latest version number', Priority.WARNING);
+    log.add('Unable to get the latest version number after ' + fetchTries + ' tries', Priority.WARNING);
     return false;
   }
   // Parse the info for the version number.

--- a/code.gs
+++ b/code.gs
@@ -2058,7 +2058,7 @@ function getEventsOnDate (eventDate, calendarId) {
 function generateEmailNotification (forceDate) {
   var now, events, contactList, calendarTimeZone, subjectPrefix, subjectBuilder, subject,
     bodyPrefix, bodySuffixes, bodyBuilder, body, htmlBody, htmlBodyBuilder,
-    contactIter;
+    contactIter, runningOutdatedVersion;
 
   log.add('generateEmailNotification() running.', Priority.INFO);
   now = forceDate || new Date();
@@ -2213,16 +2213,17 @@ function generateEmailNotification (forceDate) {
   } else {
     // If there is an email to send build the content...
     log.add('Building the email notification.', Priority.INFO);
+    runningOutdatedVersion = isRunningOutdatedVersion();
     subject = subjectPrefix + subjectBuilder.join(' - ');
     body = [bodyPrefix, '\n']
       .concat(bodyBuilder)
       .concat(['\n\n ', bodySuffixes[0], '\n '])
-      .concat('\n', isRunningOutdatedVersion() ? [bodySuffixes[1], ' ', bodySuffixes[2], ':\n', baseGitHubProjectURL + 'releases/latest', '\n '] : [])
+      .concat('\n', runningOutdatedVersion ? [bodySuffixes[1], ' ', bodySuffixes[2], ':\n', baseGitHubProjectURL + 'releases/latest', '\n '] : [])
       .join('');
     htmlBody = ['<h3>', htmlEscape(bodyPrefix), '</h3><dl>']
       .concat(htmlBodyBuilder)
       .concat(['</dl><hr/><p style="text-align:center;font-size:smaller"><a href="' + baseGitHubProjectURL + '">', htmlEscape(bodySuffixes[0]), '</a>'])
-      .concat(isRunningOutdatedVersion() ? ['<br/><br/><b>', htmlEscape(bodySuffixes[1]), ' <a href="', baseGitHubProjectURL, 'releases/latest', '">', htmlEscape(bodySuffixes[2]), '</a>.</b></p>'] : ['</p>'])
+      .concat(runningOutdatedVersion ? ['<br/><br/><b>', htmlEscape(bodySuffixes[1]), ' <a href="', baseGitHubProjectURL, 'releases/latest', '">', htmlEscape(bodySuffixes[2]), '</a>.</b></p>'] : ['</p>'])
       .join('');
 
     // ...and return it.

--- a/code.gs
+++ b/code.gs
@@ -226,17 +226,17 @@ function LocalCache () {
  * Fetch an URL, optionally making more than one try.
  *
  * @param {!string} url - The URL which has to be fetched.
- * @param {?number} [retry=1] - Number of times to try the fetch operation before failing.
+ * @param {?number} [tries=1] - Number of times to try the fetch operation before failing.
  * @returns {?Object} - The fetch response or null if the fetch failed.
  */
-LocalCache.prototype.fetch = function (url, retry) {
+LocalCache.prototype.fetch = function (url, tries) {
   var response, i;
 
-  retry = retry || 1;
+  tries = tries || 1;
 
   response = null;
   // Try fetching the data.
-  for (i = 0; i < retry; i++) {
+  for (i = 0; i < tries; i++) {
     try {
       response = UrlFetchApp.fetch(url);
       if (response.getResponseCode() !== 200) {
@@ -270,14 +270,14 @@ LocalCache.prototype.isCached = function (url) {
  * The object is loaded from the cache if present, otherwise it is fetched.
  *
  * @param {!string} url - The URL to retrieve.
- * @param {?number} retry - Number of times to retry in case of error.
+ * @param {?number} tries - Number of times to try the fetch operation before failing (passed to `this.fetch()`).
  * @returns {Object} - The response object.
  */
-LocalCache.prototype.retrieve = function (url, retry) {
+LocalCache.prototype.retrieve = function (url, tries) {
   if (this.isCached(url)) {
     return this.cache[url];
   } else {
-    return this.fetch(url, retry);
+    return this.fetch(url, tries);
   }
 };
 

--- a/code.gs
+++ b/code.gs
@@ -230,12 +230,11 @@ function LocalCache () {
  * @returns {?Object} - The fetch response or null if the fetch failed.
  */
 LocalCache.prototype.fetch = function (url, retry) {
-  var response, i, errors;
+  var response, i;
 
   retry = retry || 1;
 
   response = null;
-  errors = [];
   // Try fetching the data.
   for (i = 0; i < retry; i++) {
     try {
@@ -246,7 +245,6 @@ LocalCache.prototype.fetch = function (url, retry) {
       // Break the loop if the fetch was successful.
       break;
     } catch (error) {
-      errors.push(error);
       response = null;
       Utilities.sleep(1000);
     }


### PR DESCRIPTION
The commit messages should be self-explanatory. I encountered this because sometimes (rarely) the script version-check fails for me when contacting the github api, and I get sent logs with the two WARNING lines in the logs (one for each retrieval attempt - for the plaintext & html email-contents).

The first two commits are just cleanup/optimization which helped while I was trying to diagnose the issue.

The third commit is to hopefully reduce/eliminate the failures to reach the api.

The fourth commit is to:
- ensure the plaintext/html emails are consistent with each other in the case of transient error
- to avoid taking twice as long as expected waiting for retries
- to avoid the confusion of having two identical WARNINGs in the logs during ongoing failure

This seems OK for me under semantic test (`test()`) and syntactic test (semistandard-lint).