### PR TITLE
Fixed various problems with timezones.

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1200,9 +1200,9 @@ function SimplifiedSemanticVersion (versionNumber) {
   // Extract the pieces of information from the given string.
   matches = versionNumber.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+?))?(?:\+(.+))?$/);
   if (matches) {
-    self.numbers[0] = parseInt(matches[1]);
-    self.numbers[1] = parseInt(matches[2]);
-    self.numbers[2] = parseInt(matches[3]);
+    self.numbers[0] = parseInt(matches[1], 10);
+    self.numbers[1] = parseInt(matches[2], 10);
+    self.numbers[2] = parseInt(matches[3], 10);
     self.preRelease = isIn(matches[4], [undefined, null]) ? '' : matches[4];
     self.metadata = isIn(matches[5], [undefined, null]) ? '' : matches[5];
   } else {
@@ -2049,7 +2049,7 @@ function getEventsOnDate (year, month, day, calendarId) {
   try {
     // Look for events from 00:00:00 to 00:01:00 of the specified day.
     startDate = Utilities.formatDate(eventDate, eventCalendar.timeZone, 'yyyy-MM-dd\'T\'HH:mm:ssXXX');
-    endDate = Utilities.formatDate(new Date(eventDate.getTime() + 60 * 1000), eventCalendar.timeZone, 'yyyy-MM-dd\'T\'HH:mm:ssXXX');
+    endDate = Utilities.formatDate(new Date(eventDate.getTime() + 60000), eventCalendar.timeZone, 'yyyy-MM-dd\'T\'HH:mm:ssXXX');
     log.add('Looking for contacts events on ' + eventDate + ' (' + startDate + ' / ' + endDate + ')', Priority.INFO);
   } catch (err) {
     log.add(err.message, Priority.FATAL_ERROR);
@@ -2090,9 +2090,9 @@ function generateEmailNotification (forceDate) {
       .map(function (days) {
         var date = now.addDays(days);
         return getEventsOnDate(
-          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'yyyy')),
-          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'MM')) - 1,
-          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'dd')),
+          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'yyyy'), 10),
+          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'MM'), 10) - 1,
+          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'dd'), 10),
           settings.user.calendarId
         );
       })
@@ -2377,8 +2377,8 @@ function dateWithTimezone (year, month, day, hour, minute, second, timezoneId) {
   // Calculate the offset for the given timezone.
   offset = Utilities.formatDate(date, timezoneId, 'Z');
   // Evaluate the offset (in minutes).
-  offset = (offset[0] === '-' ? '-1' : '+1') * (parseInt(offset[1] + offset[2]) * 60 + parseInt(offset[3] + offset[4]));
+  offset = (offset[0] === '-' ? -1 : +1) * (parseInt(offset[1] + offset[2], 10) * 60 + parseInt(offset[3] + offset[4], 10));
   // Apply the offse to the UTC date to get the correct date.
-  date = new Date(date.getTime() - offset * 60 * 1000);
+  date = new Date(date.getTime() - offset * 60000);
   return date;
 }

--- a/code.gs
+++ b/code.gs
@@ -1324,6 +1324,21 @@ if (isIn(Number.isInteger, [undefined, null])) {
   };
 }
 
+if (isIn(Date.prototype.addDays, [undefined, null])) {
+  /**
+   * Generate a new date adding a number of days to a given date.
+   *
+   * @param {number} days Number of days to be added to the date.
+   * @author AnthonyWJones
+   * @see {@link https://stackoverflow.com/a/563442|Stackoverflow}
+   */
+  Date.prototype.addDays = function (days) { // eslint-disable-line no-extend-native
+    var dat = new Date(this.valueOf());
+    dat.setDate(dat.getDate() + days);
+    return dat;
+  };
+}
+
 // GLOBAL VARIABLES
 
 /**
@@ -2032,9 +2047,9 @@ function getEventsOnDate (year, month, day, calendarId) {
 
   // Query the events calendar for events on the specified date.
   try {
-    // Look for events from 00:00:00 to 01:00:00 of the specified day.
+    // Look for events from 00:00:00 to 00:01:00 of the specified day.
     startDate = Utilities.formatDate(eventDate, eventCalendar.timeZone, 'yyyy-MM-dd\'T\'HH:mm:ssXXX');
-    endDate = Utilities.formatDate(new Date(eventDate.getTime() + 1 * 60 * 60 * 1000), eventCalendar.timeZone, 'yyyy-MM-dd\'T\'HH:mm:ssXXX');
+    endDate = Utilities.formatDate(new Date(eventDate.getTime() + 60 * 1000), eventCalendar.timeZone, 'yyyy-MM-dd\'T\'HH:mm:ssXXX');
     log.add('Looking for contacts events on ' + eventDate + ' (' + startDate + ' / ' + endDate + ')', Priority.INFO);
   } catch (err) {
     log.add(err.message, Priority.FATAL_ERROR);
@@ -2073,10 +2088,11 @@ function generateEmailNotification (forceDate) {
     [],
     settings.notifications.anticipateDays
       .map(function (days) {
+        var date = now.addDays(days);
         return getEventsOnDate(
-          parseInt(Utilities.formatDate(now, settings.notifications.timeZone, 'yyyy')),
-          parseInt(Utilities.formatDate(now, settings.notifications.timeZone, 'MM')) - 1,
-          parseInt(Utilities.formatDate(now, settings.notifications.timeZone, 'dd')),
+          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'yyyy')),
+          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'MM')) - 1,
+          parseInt(Utilities.formatDate(date, settings.notifications.timeZone, 'dd')),
           settings.user.calendarId
         );
       })
@@ -2170,7 +2186,7 @@ function generateEmailNotification (forceDate) {
     .forEach(function (daysInterval) {
       var date, formattedDate;
 
-      date = new Date(now.getTime() + daysInterval * 24 * 60 * 60 * 1000);
+      date = now.addDays(daysInterval);
       formattedDate = Utilities.formatDate(date, settings.notifications.timeZone, _('dd-MM-yyyy'));
 
       eventTypes.forEach(function (eventType) {


### PR DESCRIPTION
This should fix problems such as #111 and #79, which were caused by incorrect handling of the dates with regard to different timezones.

Before actually merging this it would be great if someone whose event calendar is set on 'Pacific/Auckland' (like @kkaiser or @mile1206) or any other GMT+12:00 timezone could test this out.  
To check which timezone your calendar is set to open https://calendar.google.com, click on the arrow next to your event calendar and choose "settings": you should find the "Time zone" field near the top.  
To test the script you just have to copy the new script from [here](https://raw.githubusercontent.com/GioBonvi/GoogleContactsEventsNotifier/fix-timezones/code.gs), replace your current version with this one and edit the settings to your liking.