### PR TITLE
Various fixes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -100,9 +100,11 @@ Before submitting a PR:
 
 - If you've updated translation strings, please check that you have used the same
   format as the other entries, for example:
+
   ```javascript
   'You can find the latest one here': 'Puoi trovare l\'ultima qui',
   ```
+
   - Both the "from" and "to" parts of each entry are surrounded by single-quotes
     (`'aa'`)
   - Any single-quotes within the "from" or "to" are escaped with a backslash

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,7 +24,7 @@ What action or series of actions is the cause of the issue?
 
 ### Expected behavior
 
- What should happen?
+What should happen?
 
 ### Current behavior
 
@@ -34,9 +34,11 @@ What happens instead?
 
 - Version of the script: x.x.x - look for a line near the top of the code which
   reads:
+
   ```javascript
   version: 'w.x.y-z',
   ```
+
 - Any other details which might be related to the context;
 
 ### Extended description

--- a/code.gs
+++ b/code.gs
@@ -2078,7 +2078,7 @@ function getEventsOnDate (year, month, day, calendarId) {
 function generateEmailNotification (forceDate) {
   var now, events, contactList, subjectPrefix, subjectBuilder, subject,
     bodyPrefix, bodySuffixes, bodyBuilder, body, htmlBody, htmlBodyBuilder,
-    contactIter, runningOutdatedVersion;
+    contactIter, runningOutdatedVersion, maxSubjectLength, ellipsis;
 
   log.add('generateEmailNotification() running.', Priority.INFO);
   now = forceDate || new Date();
@@ -2237,6 +2237,12 @@ function generateEmailNotification (forceDate) {
     log.add('Building the email notification.', Priority.INFO);
     runningOutdatedVersion = isRunningOutdatedVersion();
     subject = subjectPrefix + subjectBuilder.join(' - ');
+    // An error is thrown if the subject of the email is longer than 250 characters.
+    maxSubjectLength = 250;
+    ellipsis = '...';
+    if (subject.length > maxSubjectLength) {
+      subject = subject.substr(0, maxSubjectLength - ellipsis.length) + ellipsis;
+    }
     body = [bodyPrefix, '\n']
       .concat(bodyBuilder)
       .concat(['\n\n ', bodySuffixes[0], '\n '])

--- a/docs/translation-guide.md
+++ b/docs/translation-guide.md
@@ -37,7 +37,9 @@ To add a new language:
     'You can find the latest one here': 'Puoi trovare l\'ultima qui',
   },
   ```
+
 - Paste it just below itself, like this:
+
   ```javascript
   'it': {
     'Age': 'Età',
@@ -50,6 +52,7 @@ To add a new language:
     'You can find the latest one here': 'Puoi trovare l\'ultima qui',
   },
   ```
+
 - Replace the language code of your translation with your language code and
   proceed to translate every item in the list, leaving the string on the left of
   the `:` unchanged and translating the one on the right, like this:
@@ -66,6 +69,7 @@ To add a new language:
     'You can find the latest one here': 'Die aktuelle Version findest du hier',
   },
   ```
+
 - These are some things you have to keep in mind to do this correctly:
   1. Remember to put a comma at the end of each line except after the open curly
      bracket.


### PR DESCRIPTION
Just tow small fixes.

The subject length limit "bug" was reported to me by a user via email. 250 characters surely is quite an high limit, but still... he found it while testing the script: maybe one day a user will actually have that many birthday and this will save us the trouble of spending time diagnosing and solving the problem.

Would you mark this as a bug? It's not documented anywhere, it depends on the behaviour of an external API and it's a potentially execution-breaking problem.