### PR TITLE
Group blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ missing notifications on Google Calendar Birthday Calendar.
   - [Installation and setup](#installation-and-setup)
   - [Additional information](#additional-information)
     - [Stopping/uninstalling/deleting the script](#stoppinguninstallingdeleting-the-script)
+    - [Blacklisting](#blacklisting)
+      - [Group blacklisting](#group-blacklisting)
+      - [Blacklisting specific events for specific contacts](#blacklisting-specific-events-for-specific-contacts)
     - [Translation](#translation)
     - [Bug and error reporting, help requests](#bug-and-error-reporting-help-requests)
       - [Unresponsive help requests](#unresponsive-help-requests)
@@ -63,7 +66,23 @@ steps:
    If you want to be extra sure you can wait some days to confirm that no email is
    sent to you anymore and only then delete the script file: this is up to you.
 
-### Blacklisting specific events for specific contacts
+### Blacklisting
+
+#### Group blacklisting
+
+You can set the `settings.notifications.blacklistedGroups` variable to a list of
+contact groups you do not want to receive event notifications for.  
+This can be used in two ways:
+
+- if the contacts you do not want to receive the notifications for are already
+  in a group (e.g. you might have an 'Extended family' group containing the
+  contacts of far relatives whose birthdays you are not actually interested in)
+  you can add that group name to the `blacklistedGroups` list
+- if you have a certain number of contacts that you want to blacklist, but they
+  do not share a common group you can add them to a new group (e.g:
+  'GCEN-blacklist') and add that group name to the `blacklistedGroups` list
+
+#### Blacklisting specific events for specific contacts
 
 There are three event-types for which notifications can be statically
 enabled/disabled for by editing the `settings.notifications.eventTypes`

--- a/code.gs
+++ b/code.gs
@@ -126,6 +126,23 @@ var settings = {
       CUSTOM: false
     },
     /*
+     * BLACKLISTED GROUPS
+     *
+     * You can list here any contact group you want to globally exclude from the notifications by
+     * specifying a comma separated list of group names between the square brackets.
+     * You can specify groups you already have in your contacts (e.g. 'Family', 'Work'...) or you can
+     * create a custom group (e.g the default 'GCEN-blacklist') and add all the contacts you want to
+     * blacklist to that group.
+     * If you want more granular control, like blacklisting only a certain event for a given contact
+     * have a look at the contact blacklist functionality explained in the documentation on the GitHub
+     * homepage of this project.
+     *
+     * Example:
+     *  blacklistedGroups: ['GCEN-blacklist', 'Family'],
+     *    You will not receive notifications for any contact in the GCEN-blacklist or in the Family group.
+     */
+    blacklistedGroups: [],
+    /*
      * MAXIMUM NUMBER OF EMAIL ADDRESSES
      *
      * You can limit the maximum number of email addresses displayed for each contact in the notification emails
@@ -299,6 +316,8 @@ function MergedContact () {
   this.blacklist = Object.keys(settings.notifications.eventTypes)
     .filter(function (label) { return settings.notifications.eventTypes[label] === false; })
     .map(eventLabelToLowerCase);
+  /** @type {boolean} */
+  this.isGroupBlacklisted = false;
   /** @type {ContactDataDC} */
   this.data = new ContactDataDC(
     null, // Name.
@@ -369,12 +388,18 @@ MergedContact.prototype.getInfoFromRawEvent = function (rawEvent) {
   if (this.gPlusId === null && eventData['goo.contactsProfileId']) {
     this.getInfoFromGPlus(eventData['goo.contactsProfileId']);
   }
-  // delete any events marked as blacklisted (but already added e.g. from raw event data)
-  if (this.blacklist) {
+
+  if (this.isGroupBlacklisted) {
+    // If the contact was in a blacklisted group delete all the events of the contact.
+    this.events = [];
+    log.add('Contact was group-blacklisted: deleting all its events.', Priority.INFO);
+  } else if (this.blacklist) {
+    // Delete any events marked as blacklisted (but already added e.g. from raw event data).
     self = this;
     self.blacklist.forEach(function (label) {
       self.deleteFromField('events', label, false);
     });
+    log.add('Contact had blacklisted events.', Priority.INFO);
   }
 };
 
@@ -417,13 +442,20 @@ MergedContact.prototype.getInfoFromContact = function (contactId, eventMonth, ev
     null                          // Profile image URL.
   ));
 
-  // Events blacklist.
-  blacklist = googleContact.getCustomFields('notificationBlacklist');
-  if (blacklist && blacklist[0]) {
-    self.blacklist = uniqueStrings(self.blacklist.concat(blacklist[0].getValue().replace(/,+/g, ',').replace(/(^,|,$)/g, '').split(',').map(function (x) {
-      x = x.toLocaleLowerCase();
-      return ((x === 'birthday' || x === 'anniversary') ? x : ('CUSTOM:' + x));
-    })));
+  // Check that none of the contact's group are blacklisted.
+  self.isGroupBlacklisted = googleContact.getContactGroups()
+    .map(function (group) { return settings.notifications.blacklistedGroups.indexOf(group.getName()) !== -1; })
+    .reduce(function (acc, curr) { return acc || curr; }, false);
+
+  if (!self.isGroupBlacklisted) {
+    // Per-contact events blacklist.
+    blacklist = googleContact.getCustomFields('notificationBlacklist');
+    if (blacklist && blacklist[0]) {
+      self.blacklist = uniqueStrings(self.blacklist.concat(blacklist[0].getValue().replace(/,+/g, ',').replace(/(^,|,$)/g, '').split(',').map(function (x) {
+        x = x.toLocaleLowerCase();
+        return ((x === 'birthday' || x === 'anniversary') ? x : ('CUSTOM:' + x));
+      })));
+    }
   }
 
   // Events.


### PR DESCRIPTION
I've been contacted privately by a user suggesting that it would be nice to be able to blacklist contacts en masse using contacts groups.

I found the idea interesting as it could be implemented in parallel to the already existing blacklisting functionality to offer two different levels of control: one easier to manage and broader in scope, the other more advanced and more precise.

I thought about implementing a "default" balcklisted group by having the `blacklistedGroups` array pre-populated as shown in the code example, but I fear it could lead to some confusion and add more problems than benefits.

```javascript
  blacklistedGroups: ['GCEN-blacklist'],
```
Leaving the users to add their own groups adds a little bit of work for them, but should be simpler to understand.

Let me know what you think.