### PR TITLE
add required alt attribute to img tag

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -550,7 +550,7 @@ MergedContact.prototype.getLines = function (type, date, format) {
         try {
           // Get the default profile image from the cache.
           inlineImages['contact-img-' + imgCount] = cache.retrieve(self.data.getProp('photoURL')).getBlob().setName('contact-img-' + imgCount);
-          line.push('<img src="cid:contact-img-' + imgCount + '" style="height:1.4em;margin-right:0.4em" />');
+          line.push('<img src="cid:contact-img-' + imgCount + '" style="height:1.4em;margin-right:0.4em" alt="" />');
         } catch (err) {
           log.add('Unable to get the profile picture with URL ' + self.data.getProp('photoURL'), Priority.WARNING);
         }


### PR DESCRIPTION
HTML standard requires the IMG tag to contain an ALT attribute. As in this case the image is only for illustration, I propose to supply an empty attribute to keep the code simple and the message small.

I assume people using screen readers or similar tools do use the text-version of the mail, so no need to specify something. 
It might be an option to use the full name again as well.