### PR TITLE
Update link Google Cloud Platform API Dashboard

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -121,6 +121,7 @@ From this moment on you will always receive an email before any of your
 contacts' birthday (You should have set how many days before at the beginning).
 
 [Main code file]: https://raw.githubusercontent.com/GioBonvi/GoogleContactsEventsNotifier/master/code.gs
-[Google Scripts website]: https://script.google.com
 [Google setup birthday calendar]: https://support.google.com/calendar/answer/6084659?hl=en
+[Google Scripts website]: https://script.google.com
+[Google Cloud Platform API Dashboard]: https://console.cloud.google.com/apis/dashboard
 [Permissions list]: ../README.md#permissions-required


### PR DESCRIPTION
Add link to *Google Cloud Platform API Dashboard* for install and setup documentation.
Change order of apparition of external links.