### PR TITLE
feat: add optional telegram bot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Logo](images/Logo_alpha.png)
 
-Receive customized email notifications to alert you about incoming birthdays or
-other events of your Google contacts.
+Receive customized email and Telegram notifications to alert you about
+incoming birthdays or other events of your Google contacts.
 
 Have you ever wondered why on Earth would Google Calendar provide a calendar to
 remind you of your contact birthdays, but without letting you set up

--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ permissions:
   Obviously this script needs your authorization to send you the email
   notifications. It won't send any other email to anyone.
 - **Connect to an external service**  
-  This permission is needed to check for updates and to load the profile images
-  of your contacts.
+  This permission is needed to
+  - check for updates
+  - load the profile images of your contacts
+  - send notifications to the Telegram Bot API (if enabled)
 
 ## Contributing
 

--- a/code.gs
+++ b/code.gs
@@ -47,6 +47,17 @@ var settings = {
      */
     lang: 'en'
   },
+  telegram: {
+  /*
+    * TELEGRAM BOT NOTIFICATIONS
+    *
+    * If you want to receive notifications via Telegram, set 'enabled' to true.
+    * You will need a Bot Token from @BotFather and your Chat ID.
+    */
+  enabled: false,
+  botToken: 'YOUR_BOT_TOKEN',
+  chatId: 'YOUR_CHAT_ID'
+  },
   notifications: {
     /*
      * HOUR OF THE NOTIFICATION
@@ -2519,7 +2530,13 @@ function main (forceDate) {
     });
 
     log.add('Email sent.', Priority.INFO);
+
+    // Send Telegram notification if enabled.
+    log.add('Sending Telegram notification...', Priority.INFO);
+    var telegramMessage = '<b>' + emailData.subject + '</b>\n\n' + emailData.body;
+    sendTelegram(telegramMessage);
   }
+
 
   // Send the log if the debug options say so.
   log.sendEmail(settings.user.notificationEmail, settings.user.emailSenderName);
@@ -2615,4 +2632,35 @@ function dateWithTimezone (year, month, day, hour, minute, second, timezoneId) {
   // Apply the offse to the UTC date to get the correct date.
   date = new Date(date.getTime() - offset * 60000);
   return date;
+}
+
+/**
+ * Send a notification message to a Telegram bot.
+ *
+ * @param {string} text - The message text to send.
+ */
+function sendTelegram (text) {
+  if (!settings.telegram.enabled || settings.telegram.botToken === 'YOUR_BOT_TOKEN') {
+    return;
+  }
+
+  var url = 'https://api.telegram.org/bot' + settings.telegram.botToken + '/sendMessage'
+  var payload = {
+    'chat_id': settings.telegram.chatId,
+    'text': text,
+    'parse_mode': 'HTML'
+  }
+
+  var options = {
+    'method': 'post',
+    'contentType': 'application/json',
+    'payload': JSON.stringify(payload),
+    'muteHttpExceptions': true
+  }
+
+  try {
+    UrlFetchApp.fetch(url, options);
+  } catch (e) {
+    log.add('Telegram Error: ' + e.message, Priority.WARNING);
+  }
 }

--- a/code.gs
+++ b/code.gs
@@ -48,15 +48,15 @@ var settings = {
     lang: 'en'
   },
   telegram: {
-  /*
-    * TELEGRAM BOT NOTIFICATIONS
-    *
-    * If you want to receive notifications via Telegram, set 'enabled' to true.
-    * You will need a Bot Token from @BotFather and your Chat ID.
-    */
-  enabled: false,
-  botToken: 'YOUR_BOT_TOKEN',
-  chatId: 'YOUR_CHAT_ID'
+    /*
+      * TELEGRAM BOT NOTIFICATIONS
+      *
+      * If you want to receive notifications via Telegram, set 'enabled' to true.
+      * You will need a Bot Token from @BotFather and your Chat ID.
+      */
+    enabled: false,
+    botToken: 'YOUR_BOT_TOKEN',
+    chatId: 'YOUR_CHAT_ID'
   },
   notifications: {
     /*

--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -66,6 +66,7 @@ These are the names of the variables:
 - `settings.notifications.maxPhonesCount`
 - `settings.notifications.indentSize`
 - `settings.notifications.compactGrouping`
+- `settings.telegram`
 
 ### Debugging options
 


### PR DESCRIPTION
Add an optional Telegram integration. You can create your personal bot and obtain a bot id from https://t.me/BotFather, lookup your user id and chat id (addressee id in Telegram) and write them into config. A noification message will arrive to your chatbox.